### PR TITLE
Add support for the iBooks "Original" theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ epub.end()
 * **includeTOC** _Boolean_ - If true, generate a separate Table of Contents page distinct from the one the ereader uses for navigation.
 * **numberTOC** _Boolean_ - If true, suppress the `ol` based list numbering and put our own as text. Necessary to have numbers in front of each TOC entry with most readers.
 * **calibre** _Object_ - _Optional_ If set, an object containing Calibre user fields which will be filled in on import to Calibre.
+* **ibooksSpecifiedFonts** _Boolean_ - _Optional_ If true, adds the metadata for an Apple iBooks [to declare an "original" theme](https://github.com/JayPanoz/Soma/wiki/How-to-embed-fonts#ibooks-meta) which reverts back to your initial fonts.
+
 
 A note on the calibre object: The format of this object requires a little
 discussion.  In order for Calibre to import into a custom filed you have to

--- a/index.js
+++ b/index.js
@@ -58,6 +58,7 @@ function Streampub (opts) {
   this.meta.publisher = opts.publisher
   this.meta.subject = opts.subject
   this.meta.calibre = opts.calibre
+  this.meta.ibooksSpecifiedFonts = opts.ibooksSpecifiedFonts
   this.numberTOC = opts.numberTOC
   this.includeTOC = opts.includeTOC
   this.maxId = 0
@@ -88,7 +89,8 @@ Streampub.prototype._flush = function (done) {
     'unique-identifier': 'pub-id',
     'xmlns': 'http://www.idpf.org/2007/opf',
     'prefix': 'foaf: http://xmlns.com/foaf/spec/ ' +
-              'calibre: https://calibre-ebook.com'
+              'calibre: https://calibre-ebook.com' +
+              'ibooks: http://vocabulary.itunes.apple.com/rdf/ibooks/vocabulary-extensions-1.0/'
   }})
   pkg.push({metadata: self._generateMetadata()})
   pkg.push({manifest: self._generateManifest()})
@@ -314,6 +316,9 @@ Streampub.prototype._generateMetadata = function () {
       if (!self.meta.calibre[name]) return
       metadata.push({'meta': [{_attr: {name: 'calibre:user_metadata:#' + name, content: JSON.stringify(self.meta.calibre[name])}}]})
     })
+  }
+  if (this.meta.ibooksSpecifiedFonts) {
+    metadata.push({'meta': [{_attr: {"ibooks:specified-fonts": 'true'}}]})
   }
   return metadata
 }

--- a/index.js
+++ b/index.js
@@ -89,7 +89,7 @@ Streampub.prototype._flush = function (done) {
     'unique-identifier': 'pub-id',
     'xmlns': 'http://www.idpf.org/2007/opf',
     'prefix': 'foaf: http://xmlns.com/foaf/spec/ ' +
-              'calibre: https://calibre-ebook.com' +
+              'calibre: https://calibre-ebook.com ' +
               'ibooks: http://vocabulary.itunes.apple.com/rdf/ibooks/vocabulary-extensions-1.0/'
   }})
   pkg.push({metadata: self._generateMetadata()})
@@ -318,7 +318,7 @@ Streampub.prototype._generateMetadata = function () {
     })
   }
   if (this.meta.ibooksSpecifiedFonts) {
-    metadata.push({'meta': [{_attr: {"ibooks:specified-fonts": 'true'}}]})
+    metadata.push({'meta': [{_attr: {property: "ibooks:specified-fonts"}}, "true"]})
   }
   return metadata
 }


### PR DESCRIPTION
Every reader seems to have their own extensions, this one is for Apple's Books app on macOS/iPad. 

Basically, before: if you change the font theme ever, then Apple will keep the same font for _every_ string in the book. Normally, this is OK, but that also changes the font for code samples and you can't change it back!

![Screen Shot 2020-05-23 at 9 00 19 AM](https://user-images.githubusercontent.com/49038/82731323-faeba080-9cd3-11ea-9687-a315bf525e89.png)

Adding this option lets you go back to the "original" CSS settings, a.k.a you get your original style back

![Screen Shot 2020-05-23 at 9 01 58 AM](https://user-images.githubusercontent.com/49038/82731367-41d99600-9cd4-11ea-8425-b01533731df4.png)
